### PR TITLE
adds the XCURSOR_PATH environment variable to fix cursor themes on KDE and other DEs

### DIFF
--- a/com.mikrotik.WinBox.yml
+++ b/com.mikrotik.WinBox.yml
@@ -13,6 +13,7 @@ finish-args:
   - --filesystem=/media
   - --filesystem=/run/media
   - --filesystem=/mnt
+  - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons
 
 modules:
   - name: WinBox


### PR DESCRIPTION
this is using the /run/host mounts exposed by default to all flatpaks (reference: https://docs.flatpak.org/en/latest/desktop-integration.html#icons) this is a following ot the following issue https://github.com/flathub/com.mikrotik.WinBox/issues/9 where cursors on KDE looks out of place or ugly, making it inconvenient for KDE Plasma users.

The /run/host/* paths are exposed to any flatpak are, as said in the official flatpak documentation,
> Since Flatpak 0.8.8, host icons from /usr/share/icons are exposed in the sandbox at /run/host/share/icons and $XDG_DATA_HOME/icons in /run/host/user-share/icons.

Making it suitable for use inside a flatpak in order to use the correct cursors themes.

**This does not require adding mounts to the current flatpak package, as everything is already included in the current flatpak container**