### PR TITLE
Force Qt to use xcb platform plugin

### DIFF
--- a/com.mikrotik.WinBox.yml
+++ b/com.mikrotik.WinBox.yml
@@ -14,6 +14,7 @@ finish-args:
   - --filesystem=/run/media
   - --filesystem=/mnt
   - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons
+  - --env=QT_QPA_PLATFORM=xcb
 modules:
   - name: WinBox
     buildsystem: simple


### PR DESCRIPTION
## Summary

On Wayland sessions, launching WinBox fails immediately with:

```
Warning: Could not find the Qt platform plugin "wayland" in "" (:0, )
Fatal: This application failed to start because no Qt platform plugin could be initialized.
Reinstalling the application may fix this problem.

Available platform plugins are: xcb.
```

## Root cause

- The MikroTik WinBox binary bundles its own Qt and does **not** ship the Qt wayland platform plugin.
- The manifest declares `--socket=x11` only — no `--socket=wayland`. So this is an X11-only flatpak by design.
- However, host env vars (`XDG_SESSION_TYPE=wayland`, `WAYLAND_DISPLAY`) leak through into the sandbox, so Qt's autodetection tries to load the wayland plugin and aborts since it isn't bundled.

## Fix

Add `--env=QT_QPA_PLATFORM=xcb` to `finish-args`. This forces Qt to use xcb on every host:
- **Wayland sessions:** Qt uses xcb via XWayland — consistent with the existing `--socket=x11` choice.
- **X11 sessions:** xcb is what Qt would have picked anyway — no behavior change.

This is the same pattern several other Qt flatpaks (that don't bundle the wayland plugin) use.

## Test plan

Verified locally on a Wayland session (KDE Plasma, CachyOS/Arch):

- [x] Reproduced the fatal Qt error on the current `master` build (no user overrides).
- [x] Built the patched manifest with `flatpak-builder --user --install`.
- [x] Confirmed `QT_QPA_PLATFORM=xcb` is present in the sandbox env (`flatpak run --command=env`).
- [x] Launched patched WinBox — no Qt error, GUI starts normally and connects.
- [x] Diff is minimal (single line added).